### PR TITLE
Add faker to production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ gem 'puma', '~> 3.0'
 gem 'active_model_serializers', '~> 0.10.0'
 gem 'faraday'
 gem 'rack-cors'
+gem 'faker'
+
 
 group :development, :test do
   gem 'pry-state', platform: :mri


### PR DESCRIPTION
Heroku needs faker gem in production environment for seed file to work. 