### PR TITLE
Add search by github username endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,16 @@ For a given cohort, this endpoint will return JSON of all the users that belong 
   ]
 ```
 
+#### `GET /users/by_github?name=:name`
+
+For a given github username, this endpoint will return JSON of a matching user.
+
+```javascript
+  {
+    "id"=>1, "name"=>"Drew", "github: "Dpalazzari", created_at"=>"2017-04-05", "updated_at"=>"2017-04-05", "cohort_id"=>11
+  }
+```
+
 ## Development Environment
 
 ## Production Environment

--- a/app/controllers/api/v1/users/github_controller.rb
+++ b/app/controllers/api/v1/users/github_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::Users::GithubController < Api::V1::BaseController
+
+  def show
+    user = User.find_by(github: params[:name])
+    if user 
+      render json: user
+    else
+      render status: 404
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,8 @@ Rails.application.routes.draw do
       resources :cohorts, only: [:index] do
         get '/users', to: 'cohorts/users#index'
       end
-      namespace :users do 
+      namespace :users do
+        get '/by_github', to: 'github#show'
         get '/:id/assignments', to: 'assignments#index'
         post '/:id/descriptions', to: 'descriptions#create'
         get '/:id/descriptions', to: 'descriptions#index'

--- a/spec/requests/api/v1/users/user_github_spec.rb
+++ b/spec/requests/api/v1/users/user_github_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe 'User Search by Github Endpoint', :type => :request do
+  it 'can find users by github username' do
+    user = create(:user)
+
+    get "/api/v1/users/by_github?name=#{user.github}"
+    found_user = JSON.parse(response.body)
+    
+    expect(response).to be_success
+    expect(found_user["name"]).to eq(user.name)
+  end
+
+  it 'returns 404 if no user is found' do
+    user = create(:user)
+
+    get '/api/v1/users/by_github?name=not_a_name'
+   
+    expect(response).to_not be_success
+  end
+end


### PR DESCRIPTION
I got pretty frustrated with the react auth stuff I was working on so I took a break for an easy win. I added an endpoint for searching our API for a user given their github username so that the front-end can find users by the info sent back from Auth0.

I'm actually going to update this to be a find/create I think. Then we can make one call to the API when we Auth in.

[#142810523]