### PR TITLE
Scope cors

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,10 +7,12 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins '*'
+    origins 'localhost:3000', '127.0.0.1:3000', 'https://johariwindow.herokuapp.com', 'http://johariwindow.herokuapp.com'
 
     resource '*',
       headers: :any,
       methods: [:get, :post, :put, :patch, :delete, :options, :head]
   end
 end
+
+


### PR DESCRIPTION
Allow only localhost:3000 and our production heroku application by editing `cors.rb`.

Followed the rack-cors gem documentation [here](https://github.com/cyu/rack-cors).

@wlffann @lucyconklin @Dpalazzari Only needs one review.

@case-eee FYI