### PR TITLE
Add update cohort rake task

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
   has_many :described, foreign_key: :describer_id, class_name: "Description"
   # users that this user has described
   has_many :described_users, through: :described, source: :describer
-  
+
   # who this user has been assigned to describe
   has_many :assignments, foreign_key: :assignee_id
   has_many :users_to_describe, through: :assignments, source: :assigned
@@ -42,7 +42,9 @@ class User < ApplicationRecord
 
   def add_cohort
     cohort_name = CensusService.get_cohort_by_github(github)
-    self.cohort = Cohort.find_or_create_by(name: cohort_name)
-    self.save
+    if cohort_name
+      self.cohort = Cohort.find_or_create_by(name: cohort_name)
+      self.save
+    end
   end
 end

--- a/app/services/census_service.rb
+++ b/app/services/census_service.rb
@@ -29,7 +29,7 @@ class CensusService
       req.params['q'] = username
       req.params['access_token'] = ENV['CENSUS_TOKEN']
     end
-    JSON.parse(res.body)['cohort']['name']
+    JSON.parse(res.body)['cohort']['name'] rescue nil
   end
 
 end

--- a/lib/tasks/census.rake
+++ b/lib/tasks/census.rake
@@ -1,0 +1,8 @@
+namespace :census do
+  desc "Update cohort on all users with census data"
+  task update_cohorts: :environment do
+    User.all.each do |user|
+      user.add_cohort
+    end
+  end
+end


### PR DESCRIPTION
-Add rake task that updates cohort of each user using data from census.
-Add more error handling for the user add cohort method.

Rake task can be used like this: `rake census:update_cohorts`

@Dpalazzari @lucyconklin @wlffann Needs one review.

@case-eee FYI