### PR TITLE
Sort adjectives by frequency in window

### DIFF
--- a/app/models/johari.rb
+++ b/app/models/johari.rb
@@ -42,10 +42,10 @@ class Johari
   end
 
   def get_counts(adjectives)
-    counts = adjectives.reduce(Hash.new(0)) do |freq, adj|
+    adjectives.reduce(Hash.new(0)) do |freq, adj|
       freq[adj.name] += 1
       freq
-    end
+    end.sort_by { |adj, count| count }.reverse.to_h
   end
 
   def arena_adjectives


### PR DESCRIPTION
Sort counts in reverse when they are found for each window that considers frequency. This way the most frequent adjectives will appear at the top of the list in the front-end.

@Dpalazzari @wlffann @lucyconklin Needs one review.

@case-eee FYI